### PR TITLE
Adding fill_pass_through_columns to accounting_periods model in netsu…

### DIFF
--- a/models/netsuite/stg_netsuite__accounting_periods.sql
+++ b/models/netsuite/stg_netsuite__accounting_periods.sql
@@ -43,6 +43,9 @@ final as (
         closed as is_closed,
         _fivetran_deleted
 
+        --The below macro adds the fields defined within your accounting_periods_pass_through_columns variable into the staging model
+        {{ netsuite_source.fill_pass_through_columns(var('accounting_periods_pass_through_columns', [])) }}
+        
     from fields
 )
 

--- a/models/netsuite2/stg_netsuite2__accounting_periods.sql
+++ b/models/netsuite2/stg_netsuite2__accounting_periods.sql
@@ -37,6 +37,11 @@ final as (
         alllocked = 'T' as is_all_locked,
         arlocked = 'T' as is_ar_locked,
         aplocked = 'T' as is_ap_locked
+
+         --The below macro adds the fields defined within your accounting_periods_pass_through_columns variable into the staging model
+        {{ netsuite_source.fill_pass_through_columns(var('accounting_periods_pass_through_columns', [])) }}
+
+        
     from fields
     where not coalesce(_fivetran_deleted, false)
 )


### PR DESCRIPTION
# PR: Add pass_through_columns macro support to NetSuite accounting periods models

**Please provide your name and company**  
Atharva Patil

**Link the issue/feature request which this PR is meant to address**  
This PR addresses the missing `fill_pass_through_columns` macro support in the NetSuite accounting periods models, which prevented users from including additional custom fields in their accounting period models.

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**  
This PR implements the `fill_pass_through_columns` macro in both NetSuite and NetSuite2 accounting periods staging models. Previously, while the package supported pass-through columns in other models, the accounting periods models were missing this functionality, causing fields like `parent_id` to not appear in the compiled models.

Key changes:
- Added `fill_pass_through_columns` macro usage to `stg_netsuite__accounting_periods.sql`
- Added `fill_pass_through_columns` macro usage to `stg_netsuite2__accounting_periods.sql`
- Ensured consistent implementation across both data models

**How did you validate the changes introduced within this PR?**  
Tested with both standard and custom fields to ensure the pass-through functionality works correctly. Specifically:
1. Added `parent_id` to the `accounting_periods_pass_through_columns` variable
2. Compiled and ran the models locally
3. Verified that the `parent_id` column now appears correctly in the compiled SQL and final output
4. Tested with multiple custom fields to ensure all pass-through columns work properly

**Which warehouse did you use to develop these changes?**  
BigQuery

**Did you update the CHANGELOG?**  
- [x] No

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**  
- [x] No

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**  
- [x] Yes

**If you had to summarize this PR in an emoji, which would it be?**  
:wrench: